### PR TITLE
Send template IDs along with device data

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -76,7 +76,7 @@ class Agent {
           for (let device of devices) {
             this.iotagent.getDevice(device, tenant).then((deviceinfo: DojotDevice) => {
               let deviceTemplates = (deviceinfo.templates == null ? undefined : deviceinfo.templates)
-              let [attr, templateid] = this.findLoRaId(deviceinfo, tenant);
+              let [attr, ] = this.findLoRaId(deviceinfo, tenant);
               if (attr != null) {
                 this.cacheHandler.cache[attr.static_value] = new CacheEntry(deviceinfo.id, tenant, deviceTemplates);
               }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,11 +4,13 @@ import util = require("util");
 class CacheEntry {
   public id: string;
   public tenant: string;
+  public templateIds?: string[];
 
 
-  constructor(id: string, tenant: string) {
+  constructor(id: string, tenant: string, templateIds?: string[]) {
     this.id = id;
     this.tenant = tenant;
+    this.templateIds = templateIds;
   }
 };
 

--- a/src/dojot-device.ts
+++ b/src/dojot-device.ts
@@ -3,7 +3,7 @@
   created: string;
   id: string;
   label: string;
-  templates?: (string)[] | null;
+  templates?: string[] | null;
 }
 
 export interface Attrs {


### PR DESCRIPTION
This PR adds template IDs to the message sent to Kafka with device updates. Without this info, flows (in flowbroker) that use template as input nodes won't be triggered.